### PR TITLE
Simplify npm tasks and remove eslint options

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
   "scripts": {
     "authors": "bash tools/authors",
     "clean": "npm run perfectionist && node tools/clean.js",
-    "eslint": "eslint --quiet --color tools/*.js",
+    "eslint": "eslint *.js tools",
     "lint": "npm run eslint && npm run stylelint",
     "patch": "versions -p -C patch github-community-dark.user.css",
     "minor": "versions -p -C minor github-community-dark.user.css",
     "major": "versions -p -C major github-community-dark.user.css",
     "perfectionist": "perfectionist github-community-dark.user.css github-community-dark.user.css --indentSize 2 --maxAtRuleLength 250",
     "stylelint": "stylelint --quiet --color -- github-community-dark.user.css",
-    "test": "npm run eslint && npm run stylelint",
+    "test": "npm run lint",
     "update": "updates -cu && npm install",
     "usercss": "node tools/add-themes.js && node tools/update-usercss.js"
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "authors": "bash tools/authors",
     "clean": "npm run perfectionist && node tools/clean.js",
-    "eslint": "eslint *.js tools",
+    "eslint": "eslint tools/*.js",
     "lint": "npm run eslint && npm run stylelint",
     "patch": "versions -p -C patch github-community-dark.user.css",
     "minor": "versions -p -C minor github-community-dark.user.css",


### PR DESCRIPTION
This adjusts the scripts so they more closely match the setup in GitHub Dark. I'm also trying to get the eslint output to be picked up by the GitHub Actions problem matcher.